### PR TITLE
fix #attributes not returning values for encrypted attributes in a store

### DIFF
--- a/lib/lockbox/model.rb
+++ b/lib/lockbox/model.rb
@@ -143,7 +143,28 @@ module Lockbox
                   # it is possible that the encrypted attribute is not loaded, eg.
                   # if the record was fetched partially (`User.select(:id).first`).
                   # accessing a not loaded attribute raises an `ActiveModel::MissingAttributeError`.
-                  send(lockbox_attribute[:attribute]) if has_attribute?(lockbox_attribute[:encrypted_attribute])
+                  encrypted_attribute = lockbox_attribute[:encrypted_attribute]
+                  if has_attribute?(encrypted_attribute)
+                    send(lockbox_attribute[:attribute])
+                    next
+                  end
+
+                  # encrypted attribute could be inside an ActiveRecord::Store
+                  # which doesn't expose accessors of store as attributes, so
+                  # check if attribute for store is loaded
+                  store, _ = self.class.stored_attributes.detect do |_, accessors|
+                    accessors.map(&:to_sym).include?(encrypted_attribute.to_sym)
+                  end
+                  if store
+                    # if entire store is encrypted, check if encrypted attribute
+                    # for store is loaded
+                    store_encrypted_attribute = self.class.lockbox_attributes.dig(
+                      store.to_sym, :encrypted_attribute
+                    )
+                    if has_attribute?(store_encrypted_attribute || store)
+                      send(lockbox_attribute[:attribute])
+                    end
+                  end
                 end
                 super
               end

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -72,9 +72,11 @@ class User < ActiveRecord::Base
     serialize :coordinates, Array
   end
 
-  store :credentials, accessors: [:username], coder: JSON
-  store :credentials2, accessors: [:username2], coder: JSON
+  store :credentials, accessors: [:username, :password_ciphertext], coder: JSON
+  store :credentials2, accessors: [:username2, :password2_ciphertext], coder: JSON
   has_encrypted :credentials2
+  has_encrypted :password
+  has_encrypted :password2
 
   attribute :configuration, Configuration.new
   has_encrypted :configuration2, type: Configuration.new


### PR DESCRIPTION
The `#attributes` Hash returned for an ActiveRecord object will return `nil` for lockbox attributes if the encrypted attribute is stored within an `ActiveRecord::Store`. Example using the `User` class in `test/support/active_record.rb`
```
class User < ActiveRecord::Base
  has_encrypted :email

  store :credentials, accessors: [:password_ciphertext], coder: JSON
  has_encrypted :password
end

User.create!(email: "test@example.org", password: "Passw0rd!")
user = User.last
user.attributes["email"]  # returns "test@example.org"
user.attributes["password"]  # returns nil
```