### PR TITLE
chore: simplify encrypting payload when handling DecryptionError

### DIFF
--- a/test/lockbox_test.rb
+++ b/test/lockbox_test.rb
@@ -156,9 +156,10 @@ class LockboxTest < Minitest::Test
     ciphertext = lockbox.encrypt(message)
 
     lockbox = Lockbox.new(algorithm: "hybrid", decryption_key: key_pair[:encryption_key])
-    assert_raises(Lockbox::DecryptionError, /Couldn't encrypt payload. Original payload:/) do
+    err = assert_raises(Lockbox::DecryptionError) do
       lockbox.decrypt(ciphertext)
     end
+    assert_match /Decryption failed/, err.message
   end
 
   def test_hybrid_no_encryption_key
@@ -189,9 +190,10 @@ class LockboxTest < Minitest::Test
   def test_bad_ciphertext
     lockbox = Lockbox.new(key: random_key)
 
-    assert_raises(Lockbox::DecryptionError, /Encrypted payload:/) do
+    err = assert_raises(Lockbox::DecryptionError) do
       lockbox.decrypt("0")
     end
+    assert_match /Encrypted payload:/, err.message
 
     assert_raises(Lockbox::DecryptionError) do
       lockbox.decrypt("0"*16)


### PR DESCRIPTION
Previously, we used the 'local' lockbox instance when re-encrypting the payload to log. This adds complexity and potential confusion when decrypting the payload, since we'd need to reconstruct an instance with the same context (table, attribute, whether or not to use a the org key) when attempting to diagnose the issue.

This removes that layer of complexity, and allows one to just create a lockbox instance that uses the `master_key` when decrypting the payload.

Of course, once we get the payload decrypted, we may still run into a version of the problem I describe above anyway, but at least this can remove one potential layer of confusion.